### PR TITLE
Update composer.json for Magento v2.2x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-      "symfony/console": "2.6.*",
+      "symfony/console": "~2.6.0||~2.8.0",
       "symfony/process": "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "jamescowie/composer-patcher",
     "description": "Apply patches using composer",
     "license": "MIT",
+    "version": "0.1.1",
     "authors": [
         {
             "name": "jamescowie",


### PR DESCRIPTION
Magento v2.2.x uses `symfony/console` v2.8.x instead of v2.6.x used by earlier versions of M2.