### PR TITLE
 Dry run revert to test if patch is applied

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "jamescowie/composer-patcher",
     "description": "Apply patches using composer",
     "license": "MIT",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "authors": [
         {
             "name": "jamescowie",


### PR DESCRIPTION
When dry run revert succeeds the console output logs that the patch had already
been applied instead of logging the patch failure.