### PR TITLE
add symfony console version compatible with 2.4.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "jamescowie/composer-patcher",
     "description": "Apply patches using composer",
     "license": "MIT",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "authors": [
         {
             "name": "jamescowie",
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-      "symfony/console": "~2.3, !=2.7.0||~3.0||~4.0",
+      "symfony/console": "~2.3, !=2.7.0||~3.0||~4.0||~5.0",
       "symfony/finder": "~2.3||~3.0||~4.0||~5.0",
       "symfony/process": "~4.2||~5.0",
       "composer/composer": "~1.0||~2.0"


### PR DESCRIPTION
Fix below issue by adding the symfony/console ~5.0 version to make it compatible with 2.4.6
Problem 1
    - jamescowie/composer-patcher[1.0.1, ..., 1.0.8] require symfony/console ~2.3, !=2.7.0||~3.0||~4.0 -> satisfiable by symfony/console[v2.3.0, ..., v2.8.52, v3.0.0-BETA1, ..., v3.4.47, v4.0.0-BETA1, ..., v4.4.49].
    - jamescowie/composer-patcher 1.0.0 requires symfony/console ~2.6.0||~2.8.0 -> satisfiable by symfony/console[v2.6.0-BETA1, ..., v2.8.52].